### PR TITLE
Use `cd ... && ` prefix

### DIFF
--- a/rude.el
+++ b/rude.el
@@ -41,10 +41,6 @@
                        rude-python-ts-main)))
   "Contains functions to provide candidates per mode.")
 
-(defvar rude-default-directory-alist
-  '((rust-mode . rude-rust-ts-default-directory)
-    (rust-ts-mode . rude-rust-ts-default-directory)
-    (rustic-mode . rude-rust-ts-default-directory)))
 
 (defgroup rude nil
   "Run \\[compile] based on the buffer content."
@@ -73,14 +69,9 @@ if DEBUG is set to t return `dape-command' instead."
 
 (defun rude-default-directory ()
   "Return the directory suitable for rude command."
-  (let ((fn (alist-get major-mode rude-default-directory-alist)))
-    (cond
-     ((fboundp fn)
-      (funcall fn))
-     ((project-current nil)
-      (project-root (project-current nil)))
-     (t
-      default-directory))))
+  (if (project-current nil)
+      (project-root (project-current nil))
+    default-directory))
 
 ;;;###autoload
 (defun rude-compile-thing-at-point ()

--- a/test/rude-python-ts-tests.el
+++ b/test/rude-python-ts-tests.el
@@ -31,7 +31,10 @@
                      '(debugpy-module
                        command "python3"
                        :module "unittest"
-                       :args "test_unittest.py"))))))
+                       :args "test_unittest.py")))
+      (let ((default-directory (expand-file-name "../../..")))
+        (should (equal (rude-python-ts-test-file)
+                       "python3 -m unittest test/fixtures/python-ts/test_unittest.py"))))))
 
 (ert-deftest python-ts-unittest-class ()
   (let ((rude-python-ts-test-runner "unittest"))


### PR DESCRIPTION
Instead of changing `default-directory` `rude` uses cd ... && prefix for all compile commands. This improves ergonomic because it allows to rerun previous compile commands from the history and enables the future history capability for M-x compile and M-x dape.